### PR TITLE
Adds benchmark InsertFireCancelSecondRuleBenchmark

### DIFF
--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/common/ConstraintPattern.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/common/ConstraintPattern.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.common;
+
+public class ConstraintPattern {
+    private final String variableName;
+    private final String constraint;
+
+    public ConstraintPattern(final String variableName, final String constraint) {
+        this.variableName = variableName;
+        this.constraint = constraint;
+    }
+
+    public String getVariableName() {
+        return variableName;
+    }
+
+    public String getConstraint() {
+        return constraint;
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/common/providers/RulesWithJoinsTreeProvider.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/common/providers/RulesWithJoinsTreeProvider.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.common.providers;
+
+import org.drools.benchmarks.common.ConstraintPattern;
+import org.drools.benchmarks.common.DrlProvider;
+import org.drools.benchmarks.domain.A;
+
+/**
+ * Provides rule(s) with JoinNodes. Each join is of different type in different rules, so joins are not shared.
+ */
+public class RulesWithJoinsTreeProvider implements DrlProvider {
+
+    private final int numberOfJoins;
+    private final boolean appendDrlHeader;
+    private final boolean sharedRoot;
+    private final String global;
+    private final String consequence;
+
+    public RulesWithJoinsTreeProvider(final int numberOfJoins, final boolean appendDrlHeader) {
+        this(numberOfJoins, appendDrlHeader, false, "", "");
+    }
+
+    /**
+     * Constructor.
+     * @param numberOfJoins Required number of joins that each rule in provided DRL will contain.
+     * This number is limited to maximum number of 4 joins in each rule.
+     * @param appendDrlHeader True, if DRL header should be appended to provided DRL, else false.
+     * @param sharedRoot If true, the root constraint is shared between rules.
+     * @param global DRL global.
+     * @param consequence Rule consequence.
+     */
+    public RulesWithJoinsTreeProvider(final int numberOfJoins, final boolean appendDrlHeader, final boolean sharedRoot,
+            final String global, final String consequence) {
+        if (numberOfJoins > 4) {
+            throw new IllegalArgumentException(
+                    "Unsupported number of joins! Maximal allowed number of joins is 4, actual is " + numberOfJoins);
+        }
+        this.numberOfJoins = numberOfJoins;
+        this.appendDrlHeader = appendDrlHeader;
+        this.sharedRoot = sharedRoot;
+        this.global = global;
+        this.consequence = consequence;
+    }
+
+    @Override
+    public String getDrl() {
+        return getDrl(1);
+    }
+
+    @Override
+    public String getDrl(int numberOfRules) {
+        final StringBuilder drlBuilder = new StringBuilder();
+
+        if (appendDrlHeader) {
+            drlBuilder.append("import " + A.class.getPackage().getName() + ".*;\n");
+        }
+        drlBuilder.append( global + "\n" );
+        for ( int i = 0; i < numberOfRules; i++ ) {
+            drlBuilder.append( "rule R" + i + " \n");
+            drlBuilder.append( " when\n");
+            appendJoins(drlBuilder, i);
+            drlBuilder.append( "then\n" );
+            drlBuilder.append( consequence + "\n" );
+            drlBuilder.append( "end\n" );
+        }
+        return drlBuilder.toString();
+    }
+
+    private void appendJoins(final StringBuilder drlBuilder, final int ruleNumber) {
+        final ConstraintPattern[] joinConstraints = getJoinConstraints();
+        String variableNameForJoinConstraint = "$a";
+        if (sharedRoot) {
+            drlBuilder.append("  " + variableNameForJoinConstraint + " : A( value == 0 )\n");
+        } else {
+            drlBuilder.append("  " + variableNameForJoinConstraint + " : A( value > " + ruleNumber + " )\n");
+        }
+        for (int i = 0; i < numberOfJoins; i++) {
+            final ConstraintPattern joinConstraint = joinConstraints[getJoinConstraintIndex(ruleNumber, i, joinConstraints.length)];
+            drlBuilder.append(joinConstraint.getConstraint().replace("${variable}", variableNameForJoinConstraint));
+            variableNameForJoinConstraint = joinConstraint.getVariableName();
+        }
+    }
+
+    private int getJoinConstraintIndex(final int indexOffset, final int requiredIndex, final int constraintsSize) {
+        return (requiredIndex + indexOffset) % constraintsSize;
+    }
+
+    private ConstraintPattern[] getJoinConstraints() {
+        return new ConstraintPattern[] {
+                new ConstraintPattern("$b", "  $b : B( value > ${variable}.value )\n"),
+                new ConstraintPattern("$c", "  $c : C( value > ${variable}.value )\n"),
+                new ConstraintPattern("$d", "  $d : D( value > ${variable}.value )\n"),
+                new ConstraintPattern("$e", "  $e : E( value > ${variable}.value )\n")
+        };
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/common/util/TestUtil.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/common/util/TestUtil.java
@@ -16,6 +16,11 @@
 
 package org.drools.benchmarks.common.util;
 
+import org.drools.benchmarks.domain.B;
+import org.drools.benchmarks.domain.C;
+import org.drools.benchmarks.domain.D;
+import org.drools.benchmarks.domain.E;
+import org.kie.api.runtime.KieSession;
 import org.kie.internal.builder.conf.RuleEngineOption;
 
 public final class TestUtil {
@@ -38,6 +43,32 @@ public final class TestUtil {
 
     public static boolean dumpRete() {
         return isDebug() || Boolean.TRUE.toString().equals(System.getProperty(Constants.PROP_KEY_DUMP_RETE));
+    }
+
+    public static void insertJoinedFactsToSession(final KieSession kieSession, final int numberOfJoins, final int baseFactValue) {
+        switch (numberOfJoins) {
+
+            case 1:
+                kieSession.insert( new B( baseFactValue + 3 ) );
+                break;
+            case 2:
+                kieSession.insert( new B( baseFactValue + 3 ) );
+                kieSession.insert( new C( baseFactValue + 4 ) );
+                break;
+            case 3:
+                kieSession.insert( new B( baseFactValue + 3 ) );
+                kieSession.insert( new C( baseFactValue + 4 ) );
+                kieSession.insert( new D( baseFactValue + 5 ) );
+                break;
+            case 4:
+                kieSession.insert( new B( baseFactValue + 3 ) );
+                kieSession.insert( new C( baseFactValue + 4 ) );
+                kieSession.insert( new D( baseFactValue + 5 ) );
+                kieSession.insert( new E( baseFactValue + 6 ) );
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported number of joins (" + numberOfJoins + ")!");
+        }
     }
 
     private TestUtil() {

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/session/InsertFireCancelSecondRuleBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/session/InsertFireCancelSecondRuleBenchmark.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.benchmarks.session;
+
+import org.drools.benchmarks.common.AbstractBenchmark;
+import org.drools.benchmarks.common.DrlProvider;
+import org.drools.benchmarks.common.providers.RulesWithJoinsTreeProvider;
+import org.drools.benchmarks.domain.A;
+import org.drools.benchmarks.domain.B;
+import org.drools.benchmarks.domain.C;
+import org.drools.benchmarks.domain.D;
+import org.drools.benchmarks.domain.E;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+
+/**
+ * Two rules, both match in the beginning. During fire, first rule modifies
+ * knowledge so the second rule doesn't fire.
+ */
+public class InsertFireCancelSecondRuleBenchmark extends AbstractBenchmark {
+
+    @Param({"1", "2", "3", "4"})
+    private int joinsNr;
+
+    @Param({"1", "4", "16"})
+    private int factsNr;
+
+    private int numberOfRules = 2;
+
+    @Setup
+    public void setupKieBase() {
+        final DrlProvider drlProvider = new RulesWithJoinsTreeProvider(joinsNr, true, true,
+                "", "modify($a) {setValue(-1)};");
+        createKieBaseFromDrl(drlProvider.getDrl(numberOfRules));
+    }
+
+    @Setup(Level.Iteration)
+    @Override
+    public void setup() {
+        createKieSession();
+        kieSession.insert( new A( 0) );
+        for ( int i = 0; i < factsNr; i++ ) {
+            // All fact types must be inserted because each rule contains different type joined.
+            kieSession.insert( new B( numberOfRules + 3 ) );
+            kieSession.insert( new C( numberOfRules + 4 ) );
+            kieSession.insert( new D( numberOfRules + 5 ) );
+            kieSession.insert( new E( numberOfRules + 6 ) );
+        }
+    }
+
+    @Benchmark
+    public int test() {
+        return kieSession.fireAllRules();
+    }
+}

--- a/drools-benchmarks/src/main/java/org/drools/benchmarks/session/RuleUnlinkingBenchmark.java
+++ b/drools-benchmarks/src/main/java/org/drools/benchmarks/session/RuleUnlinkingBenchmark.java
@@ -20,10 +20,8 @@ import java.util.concurrent.TimeUnit;
 import org.drools.benchmarks.common.AbstractBenchmark;
 import org.drools.benchmarks.common.DrlProvider;
 import org.drools.benchmarks.common.providers.RulesWithJoinsProvider;
+import org.drools.benchmarks.common.util.TestUtil;
 import org.drools.benchmarks.domain.A;
-import org.drools.benchmarks.domain.B;
-import org.drools.benchmarks.domain.C;
-import org.drools.benchmarks.domain.D;
 import org.kie.api.runtime.rule.FactHandle;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Level;
@@ -70,22 +68,7 @@ public class RuleUnlinkingBenchmark extends AbstractBenchmark {
 
         aFH = kieSession.insert( new A( rulesNr + 1 ) );
         for ( int i = 0; i < factsNr; i++ ) {
-            switch (joinsNr) {
-                case 1:
-                    kieSession.insert( new B( rulesNr + 3 ) );
-                    break;
-                case 2:
-                    kieSession.insert( new B( rulesNr + 3 ) );
-                    kieSession.insert( new C( rulesNr + 4 ) );
-                    break;
-                case 3:
-                    kieSession.insert( new B( rulesNr + 3 ) );
-                    kieSession.insert( new C( rulesNr + 4 ) );
-                    kieSession.insert( new D( rulesNr + 5 ) );
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unsupported number of joins (" + joinsNr + ")!");
-            }
+            TestUtil.insertJoinedFactsToSession(kieSession, joinsNr, rulesNr);
         }
 
         kieSession.fireAllRules();


### PR DESCRIPTION
Added benchmark is required to measure the cost of unlinking
vs. size of crossproduct.